### PR TITLE
Fixed compatibility with vim and other editors

### DIFF
--- a/reader.cc
+++ b/reader.cc
@@ -318,12 +318,14 @@ void InitDaemon(const std::vector<std::string>& files) {
         i += EVENT_SIZE + event->len;
 
         // Must be a modify event
-        if (!(event->mask & IN_MODIFY))
+        if (!(event->mask & IN_MODIFY)) {
           continue;
+        }
 
         // Length of file path must be positive
-        if (event->len <= 0)
+        if (event->len <= 0) {
           continue;
+        }
 
         // Path to modified file
         std::string name = event->name;

--- a/reader.h
+++ b/reader.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <sys/epoll.h>
 #include <sys/inotify.h>
 #include <unistd.h>
+#include <libgen.h>
 }
 
 #include <atomic>
@@ -32,6 +33,8 @@ extern "C" {
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <set>
+#include <algorithm>
 
 #include "config_bool.h"
 #include "config_double.h"


### PR DESCRIPTION
This patch resolves an issue where ConfigurationReader would not trigger on configuration file changes made with vim and some other editors.

Some text editors do not generate inotify MODIFY events when watching the files directly; in order for changes to be detected we must inotify_add_watch the parent directory (See [Analysis of inotify events for different editors](https://github.com/guard/guard/wiki/Analysis-of-inotify-events-for-different-editors).)